### PR TITLE
humble contributions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,19 @@
 import codecs
-from setuptools import setup
-from webssh._version import __version__ as version
+import os
 
+from setuptools import setup
 
 with codecs.open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
+__version__ = None
+with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'webssh',
+                       "_version.py")) as version_file:
+    exec(version_file.read())
 
 setup(
     name='webssh',
-    version=version,
+    version=__version__,
     description='Web based ssh client',
     long_description=long_description,
     author='Shengdun Hua',

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -152,7 +152,7 @@ class TestAppBasic(AsyncHTTPTestCase):
         data = json.loads(to_str(response.body))
         self.assertIsNone(data['encoding'])
         self.assertIsNone(data['id'])
-        self.assertIn('Authentication failed.', data['status'])
+        self.assertIn('Authentication failed', data['status'])
 
     def test_app_with_correct_credentials(self):
         response = self.sync_post(self.body)

--- a/tests/test_trusted_downstream.py
+++ b/tests/test_trusted_downstream.py
@@ -1,0 +1,24 @@
+import unittest
+
+from tornado.options import options
+
+from webssh.main import http_server_arguments
+
+
+class TestStartWebServer(unittest.TestCase):
+    def test_parsing_of_trusted_downstream(self):
+        options.trusted_downstream = "172.17.0.1,127.0.0.1"
+
+        http_server_kwargs = http_server_arguments()
+        self.assertEqual(http_server_kwargs["trusted_downstream"],
+                         ['172.17.0.1', '127.0.0.1'])
+
+    def test_parsing_of_empty_trusted_downstream(self):
+        options.trusted_downstream = ""
+        http_server_kwargs = http_server_arguments()
+        self.assertNotIn("trusted_downstream", http_server_kwargs.keys())
+
+    def test_parsing_of_none_trusted_downstream(self):
+        options.trusted_downstream = None
+        http_server_kwargs = http_server_arguments()
+        self.assertNotIn("trusted_downstream", http_server_kwargs.keys())

--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -63,6 +63,24 @@ class MixinHandler(object):
         logging.warning('Bad nginx configuration.')
         return False
 
+    def get_client_addr(self):
+        pass
+
+    def custom_log(self, message):
+        logging.info(self._custom_log_message(message))
+
+    def custom_logdebug(self, message):
+        logging.debug(self._custom_log_message(message))
+
+    def custom_log_error(self, message):
+        logging.error(self._custom_log_message(message))
+
+    def _custom_log_message(self, message):
+        remote_addr = self.get_client_addr()
+        if remote_addr:
+            remote_addr = remote_addr[0]
+        return "Client='%s' %s" % (remote_addr, message)
+
 
 class IndexHandler(MixinHandler, tornado.web.RequestHandler):
 
@@ -164,7 +182,7 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
         pkey = self.get_pkey_obj(privatekey, password, self.filename) \
             if privatekey else None
         args = (hostname, port, username, password, pkey)
-        logging.debug(args)
+        self.custom_logdebug(args)
         return args
 
     def get_client_addr(self):
@@ -194,16 +212,19 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
             raise tornado.web.HTTPError(400, str(exc))
 
         dst_addr = (args[0], args[1])
-        logging.info('Connecting to {}:{}'.format(*dst_addr))
+        self.custom_log('Connecting to {}:{}'.format(*dst_addr))
 
         try:
             ssh.connect(*args, timeout=6)
+            self.custom_log("Authentication successful for user='{}'.".format(
+                self.get_value('username')))
         except socket.error:
             raise ValueError('Unable to connect to {}:{}'.format(*dst_addr))
         except paramiko.BadAuthenticationType:
             raise ValueError('Bad authentication type.')
         except paramiko.AuthenticationException:
-            raise ValueError('Authentication failed.')
+            raise ValueError("Authentication failed for user='{}'.".format(
+                self.get_value('username')))
         except paramiko.BadHostKeyException:
             raise ValueError('Bad host key.')
 
@@ -218,7 +239,8 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
         try:
             worker = self.ssh_connect()
         except Exception as exc:
-            logging.error(traceback.format_exc())
+            self.custom_log_error(str(exc))
+            self.custom_log_error(traceback.format_exc())
             future.set_exception(exc)
         else:
             future.set_result(worker)
@@ -255,11 +277,15 @@ class WsockHandler(MixinHandler, tornado.websocket.WebSocketHandler):
         self.worker_ref = None
 
     def get_client_addr(self):
-        return self.get_real_client_addr() or self.stream.socket.getpeername()
+        addr = self.get_real_client_addr()
+        if addr:
+            return addr
+        if self.stream and self.stream.socket:
+            return self.stream.socket.getpeername()
 
     def open(self):
         self.src_addr = self.get_client_addr()
-        logging.info('Connected from {}:{}'.format(*self.src_addr))
+        self.custom_log('Connected from {}:{}'.format(*self.src_addr))
         try:
             worker_id = self.get_value('id')
         except (tornado.web.MissingArgumentError, InvalidValueError) as exc:
@@ -276,7 +302,7 @@ class WsockHandler(MixinHandler, tornado.websocket.WebSocketHandler):
                 self.close(reason='Websocket authentication failed.')
 
     def on_message(self, message):
-        logging.debug('{!r} from {}:{}'.format(message, *self.src_addr))
+        self.custom_logdebug('{!r} from {}:{}'.format(message, *self.src_addr))
         worker = self.worker_ref()
         try:
             msg = json.loads(message)
@@ -300,14 +326,14 @@ class WsockHandler(MixinHandler, tornado.websocket.WebSocketHandler):
 
     def on_close(self):
         if self.close_reason:
-            logging.info(
-                'Disconnecting to {}:{} with reason: {reason}'.format(
+            self.custom_log(
+                'Disconnecting from {}:{} with reason: {reason}'.format(
                     *self.src_addr, reason=self.close_reason
                 )
             )
         else:
             self.close_reason = 'client disconnected'
-            logging.info('Disconnected from {}:{}'.format(*self.src_addr))
+            self.custom_log('Disconnected from {}:{}'.format(*self.src_addr))
 
         worker = self.worker_ref() if self.worker_ref else None
         if worker:

--- a/webssh/settings.py
+++ b/webssh/settings.py
@@ -25,6 +25,8 @@ define('sysHostFile', default='', help='System wide host keys file')
 define('wpIntvl', type=int, default=0, help='Websocket ping interval')
 define('version', type=bool, help='Show version information',
        callback=print_version)
+define('trusted_downstream', default=None,
+       help='Comma-separated list of trusted downstream hosts.')
 
 
 base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
hi, i like your project and want to give some feedback:

- When running webssh behind a proxy the X-Real-IP field is currently not used by tornado. This is fixed by addding xheaders=True and a list of trusted proxies.
- Currently most of the logs do not contain the remote ip address. This is necessary to prevent ddos and abuse with e.g. fail2ban.
- Added access control to be able to restrict ssh access to only a few hosts (see security.acl).
