### PR TITLE
Need a passphrase to decrypt, not password

### DIFF
--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -157,7 +157,7 @@ class TestPrivateKey(unittest.TestCase):
         pk = self.get_pk_obj(fname, password='wrongpass')
         with self.assertRaises(InvalidValueError) as ctx:
             pk.get_pkey_obj()
-        self.assertIn('wrong password', str(ctx.exception))
+        self.assertIn('wrong passphrase', str(ctx.exception))
 
         pk = self.get_pk_obj(fname, password=password)
         self.assertIsInstance(pk.get_pkey_obj(), klass)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -152,7 +152,7 @@ class TestPrivateKey(unittest.TestCase):
         pk = self.get_pk_obj(fname, password='')
         with self.assertRaises(InvalidValueError) as ctx:
             pk.get_pkey_obj()
-        self.assertIn('Need a password', str(ctx.exception))
+        self.assertIn('Need a passphrase', str(ctx.exception))
 
         pk = self.get_pk_obj(fname, password='wrongpass')
         with self.assertRaises(InvalidValueError) as ctx:

--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -153,7 +153,7 @@ class PrivateKey(object):
         try:
             return pkeycls.from_private_key(self.iostr, password=password)
         except paramiko.PasswordRequiredException:
-            raise InvalidValueError('Need a password to decrypt the key.')
+            raise InvalidValueError('Need a passphrase to decrypt the key.')
         except paramiko.SSHException as exc:
             logging.error(str(exc))
             msg = 'Invalid key'

--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -158,7 +158,7 @@ class PrivateKey(object):
             logging.error(str(exc))
             msg = 'Invalid key'
             if self.password:
-                msg += ' or wrong password "{}" for decrypting it.'.format(
+                msg += ' or wrong passphrase "{}" for decrypting it.'.format(
                         self.password)
             raise InvalidValueError(msg)
 


### PR DESCRIPTION
While it is true that the exception called is "PasswordRequiredException", returning a message of needing a "passphrase" instead will clue the reader in that their key's password needs to go into the "Passphrase" box.