### PR TITLE
add Prometheus exporter.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ var/
 *.egg
 
 # PyInstaller
-#  Usually these files are written by a python script from a template 
+#  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
@@ -63,3 +63,6 @@ target/
 
 # known_hosts file
 known_hosts
+
+# vcode
+.vscode/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 paramiko==2.7.1
 tornado==5.1.1; python_version < '3.5'
 tornado==6.0.4; python_version >= '3.5'
+tornado-prometheus==0.1.1

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     ],
     install_requires=[
         'tornado>=4.5.0',
+        'tornado-prometheus>=0.1.1',
         'paramiko>=2.3.1',
     ],
 )

--- a/webssh/main.py
+++ b/webssh/main.py
@@ -9,6 +9,7 @@ from webssh.settings import (
     get_app_settings,  get_host_keys_settings, get_policy_setting,
     get_ssl_context, get_server_settings, check_encoding_setting
 )
+from tornado_prometheus import PrometheusMixIn, MetricsHandler
 
 
 def make_handlers(loop, options):
@@ -18,14 +19,18 @@ def make_handlers(loop, options):
     handlers = [
         (r'/', IndexHandler, dict(loop=loop, policy=policy,
                                   host_keys_settings=host_keys_settings)),
-        (r'/ws', WsockHandler, dict(loop=loop))
+        (r'/ws', WsockHandler, dict(loop=loop)),
+        (r"/metrics", MetricsHandler)
     ]
     return handlers
 
 
 def make_app(handlers, settings):
+    class WebsshApplication(PrometheusMixIn, tornado.web.Application):
+        pass
+
     settings.update(default_handler_class=NotFoundHandler)
-    return tornado.web.Application(handlers, **settings)
+    return WebsshApplication(handlers, **settings)
 
 
 def app_listen(app, port, address, server_settings):


### PR DESCRIPTION
Add Prometheus exporter support.

Supports monitoring by [Prometheus](https://prometheus.io/)  using [globocom/tornado-prometheus](https://github.com/globocom/tornado-prometheus) exporter.

Monitoring is one of the essential elements to run in a product environment, so I think it is very useful to have it enabled by default.
Also, when running on Kubernetes, Prometheus monitoring is the most common.