### PR TITLE
Configure 'template_path' and 'static_path' locations via command line arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ target/
 
 # known_hosts file
 known_hosts
+venv/

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ wssh --logging=debug
 # log to file
 wssh --log-file-prefix=main.log
 
+# specify alternative location for template material
+wssh --template_path=/templates
+
+# specify alternative location for static material
+wssh --static_path=/static
+
 # more options
 wssh --help
 ```

--- a/webssh/settings.py
+++ b/webssh/settings.py
@@ -54,9 +54,12 @@ Example: --encoding='utf-8' to solve the problem with some switches&routers''')
 define('version', type=bool, help='Show version information',
        callback=print_version)
 
-
 base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 font_dirs = ['webssh', 'static', 'css', 'fonts']
+
+define('template_path', default=os.path.join(base_dir, 'webssh', 'templates'))
+define('static_path', default=os.path.join(base_dir, 'webssh', 'static'))
+
 max_body_size = 1 * 1024 * 1024
 
 
@@ -75,8 +78,8 @@ class Font(object):
 
 def get_app_settings(options):
     settings = dict(
-        template_path=os.path.join(base_dir, 'webssh', 'templates'),
-        static_path=os.path.join(base_dir, 'webssh', 'static'),
+        template_path=options.template_path,
+        static_path=options.static_path,
         websocket_ping_interval=options.wpintvl,
         debug=options.debug,
         xsrf_cookies=options.xsrf,


### PR DESCRIPTION
Added command line arguments to enable the user to specify an alternative location to load 'templates' and 'static' artefacts.
