### PR TITLE
upgrade paramiko to 2.7.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-paramiko==2.7.1
+paramiko==2.7.2
 tornado==5.1.1; python_version < '3.5'
 tornado==6.0.4; python_version >= '3.5'


### PR DESCRIPTION
This fix an error `q must be exactly 160, 224, or 256 bits long` when using private keys.