### PR TITLE
improve: add `/xsrf` endpoint to get XSRF token only

### DIFF
--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -7,6 +7,7 @@ import traceback
 import weakref
 import paramiko
 import tornado.web
+from tornado import escape
 
 from concurrent.futures import ThreadPoolExecutor
 from tornado.ioloop import IOLoop
@@ -581,3 +582,12 @@ class WsockHandler(MixinHandler, tornado.websocket.WebSocketHandler):
         worker = self.worker_ref() if self.worker_ref else None
         if worker:
             worker.close(reason=self.close_reason)
+
+class XSRFHandler(MixinHandler, tornado.web.RequestHandler):
+
+    def initialize(self, loop=None):
+        super(XSRFHandler, self).initialize(loop)
+        self.result = dict(xsrf=escape.native_str(self.xsrf_token))
+
+    def get(self):
+        self.write(self.result)

--- a/webssh/main.py
+++ b/webssh/main.py
@@ -4,7 +4,7 @@ import tornado.ioloop
 
 from tornado.options import options
 from webssh import handler
-from webssh.handler import IndexHandler, WsockHandler, NotFoundHandler
+from webssh.handler import IndexHandler, WsockHandler, NotFoundHandler, XSRFHandler
 from webssh.settings import (
     get_app_settings,  get_host_keys_settings, get_policy_setting,
     get_ssl_context, get_server_settings, check_encoding_setting
@@ -18,6 +18,7 @@ def make_handlers(loop, options):
     handlers = [
         (r'/', IndexHandler, dict(loop=loop, policy=policy,
                                   host_keys_settings=host_keys_settings)),
+        (r'/xsrf', XSRFHandler, dict()),
         (r'/ws', WsockHandler, dict(loop=loop))
     ]
     return handlers


### PR DESCRIPTION
Webssh might be used a backend service for an other large system. And so
this system must do a first HTTP request to get XSRF token. To make
getting XSRF token more convenient, let's make a special endpoint that
returns a TSRF token is the JSON response (it is more convenient than
parsing HTML form from index page).