### PR TITLE
Publish docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 dist: xenial
 language: python
 
+services:
+  - docker
+
+env:
+  - DOCKER_REGISTRY=docker.io DOCKER_REPOSITORY=huashengdun/webssh
+
 python:
   - "2.7"
   - "3.4"
@@ -17,6 +23,26 @@ install:
 script:
   - pytest --cov=webssh
   - flake8
-
+  
 after_success:
   - codecov
+
+jobs:
+  include:
+    - stage: deploy
+      script: docker build -t webssh:build .
+      deploy:
+        - provider: script
+          script: >-
+            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin &&
+            docker tag webssh:build "${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}:latest" &&
+            docker push "${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}:latest"
+          on:
+            branch: master
+        - provider: script
+          script: >-
+            docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" &&
+            docker tag webssh:build "${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}:$TRAVIS_TAG" &&
+            docker push "${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}:$TRAVIS_TAG"
+          on:
+            tags: true


### PR DESCRIPTION
Add a deploy stage to the travis build to publish a latest docker image to a registry for master and releases.

There seem to be a lot of webssh images on docker, it would be nice to have an official, regularly updated one to rely on..

If you agree that its a good idea, this PR would also require that you create a dockerhub account, and add the DOCKER_USERNAME and DOCKER_PASSWORD values to travis to be able to push the image.