### PR TITLE
lock destination parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ A simple web application to be used as an ssh client to connect to your ssh serv
 # start a http server with specified listen address and listen port
 wssh --address='2.2.2.2' --port=8000
 
+# lock destination address and port
+wssh --dstaddress='127.0.0.1' --dstport=22
+
 # start a https server, certfile and keyfile must be passed
 wssh --certfile='/path/to/cert.crt' --keyfile='/path/to/cert.key'
 

--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -362,13 +362,17 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
         return value, filename
 
     def get_hostname(self):
-        value = self.get_value('hostname')
+        value = self.settings.get('dstaddress')
+        if not value:                    
+            value = self.get_value('hostname')
         if not (is_valid_hostname(value) or is_valid_ip_address(value)):
             raise InvalidValueError('Invalid hostname: {}'.format(value))
         return value
 
     def get_port(self):
-        value = self.get_argument('port', u'')
+        value = self.settings.get('dstport',u'')
+        if not value:
+            value = self.get_argument('port', u'')
         if not value:
             return DEFAULT_PORT
 
@@ -482,7 +486,7 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
         pass
 
     def get(self):
-        self.render('index.html', debug=self.debug, font=self.font)
+        self.render('index.html', debug=self.debug, font=self.font, fixhost=self.settings.get('dstaddress'), fixport=self.settings.get('dstport'))
 
     @tornado.gen.coroutine
     def post(self):

--- a/webssh/settings.py
+++ b/webssh/settings.py
@@ -18,7 +18,6 @@ def print_version(flag):
         print(__version__)
         sys.exit(0)
 
-
 define('address', default='', help='Listen address')
 define('port', type=int, default=8888,  help='Listen port')
 define('ssladdress', default='', help='SSL listen address')
@@ -53,7 +52,8 @@ define('encoding', default='',
 Example: --encoding='utf-8' to solve the problem with some switches&routers''')
 define('version', type=bool, help='Show version information',
        callback=print_version)
-
+define('dstaddress', default='', help='Fix destination address')
+define('dstport', default='', help='Fix destination port')
 
 base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 font_dirs = ['webssh', 'static', 'css', 'fonts']
@@ -79,13 +79,15 @@ def get_app_settings(options):
         static_path=os.path.join(base_dir, 'webssh', 'static'),
         websocket_ping_interval=options.wpintvl,
         debug=options.debug,
-        xsrf_cookies=options.xsrf,
+        xsrf_cookies=options.xsrf,        
         font=Font(
             get_font_filename(options.font,
                               os.path.join(base_dir, *font_dirs)),
             font_dirs[1:]
         ),
-        origin_policy=get_origin_setting(options)
+        origin_policy=get_origin_setting(options),
+        dstaddress=options.dstaddress,
+        dstport=options.dstport
     )
     return settings
 

--- a/webssh/templates/index.html
+++ b/webssh/templates/index.html
@@ -42,13 +42,13 @@
     <div class="container form-container" style="display: none">
       <form id="connect" action="" method="post" enctype="multipart/form-data"{% if debug %} novalidate{% end %}>
         <div class="row">
-          <div class="col">
+          <div class="col" id="hostcol"{% if fixhost %} hidden{% end %}>
             <label for="Hostname">Hostname</label>
-            <input class="form-control" type="text" id="hostname" name="hostname" value="" required>
+            <input class="form-control" type="text" id="hostname" name="hostname" value="{{fixhost}}" required>
           </div>
-          <div class="col">
+          <div class="col" id="portcol"{% if fixport %} hidden{% end %}>
             <label for="Port">Port</label>
-            <input class="form-control" type="number" id="port" name="port" placeholder="22" value="" min=1 max=65535>
+            <input class="form-control" type="number" id="port" name="port" placeholder="22" value="{{fixport}}" min=1 max=65535>
           </div>
         </div>
         <div class="row">


### PR DESCRIPTION
Added parameters to lock destinationhost or destinationport in place.
You can use this to have access to a certain server (like localhost) and not creating a jump host