### PR TITLE
timeout on exec_command

### DIFF
--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -427,7 +427,9 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
 
         for command in commands:
             try:
-                _, stdout, _ = ssh.exec_command(command, get_pty=True, timeout=1)
+                _, stdout, _ = ssh.exec_command(command,
+                                                get_pty=True,
+                                                timeout=1)
             except paramiko.SSHException as exc:
                 logging.info(str(exc))
             else:

--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -427,15 +427,18 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
 
         for command in commands:
             try:
-                _, stdout, _ = ssh.exec_command(command, get_pty=True)
+                _, stdout, _ = ssh.exec_command(command, get_pty=True, timeout=1)
             except paramiko.SSHException as exc:
                 logging.info(str(exc))
             else:
-                data = stdout.read()
-                logging.debug('{!r} => {!r}'.format(command, data))
-                result = self.parse_encoding(data)
-                if result:
-                    return result
+                try:
+                    data = stdout.read()
+                    logging.debug('{!r} => {!r}'.format(command, data))
+                    result = self.parse_encoding(data)
+                    if result:
+                        return result
+                except socket.timeout:
+                    pass
 
         logging.warning('Could not detect the default encoding.')
         return 'utf-8'


### PR DESCRIPTION
get_default_encoding method can't get the encoding If ssh session doesn't give a prompt (i.e. showing a whiptail menu after login)

Adding timeout to exec_command method fix it.