### PR TITLE
use secrets to generate worker id

### DIFF
--- a/webssh/worker.py
+++ b/webssh/worker.py
@@ -1,4 +1,5 @@
 import logging
+import secrets
 import tornado.websocket
 
 from tornado.ioloop import IOLoop
@@ -36,7 +37,7 @@ class Worker(object):
         self.chan = chan
         self.dst_addr = dst_addr
         self.fd = chan.fileno()
-        self.id = str(id(self))
+        self.id = self.gen_id()
         self.data_to_dst = []
         self.handler = None
         self.mode = IOLoop.READ
@@ -49,6 +50,10 @@ class Worker(object):
             self.on_write()
         if events & IOLoop.ERROR:
             self.close(reason='error event occurred')
+
+    @classmethod
+    def gen_id(cls):
+        return secrets.token_urlsafe(nbytes=32)
 
     def set_handler(self, handler):
         if not self.handler:


### PR DESCRIPTION
The worker ID right now is typically based off the address of an object in memory. This could be guessed. While the worker is tied to a specific IP, there is a chance an off-path attacker could be hosted behind the same IP as the caller. They could possibly guess the worker id of an unclaimed session by observing the sequence of IDs presented to themselves, leading to them gaining access to an already authenticated SSH session.

Use the python secrets module to generate a cryptographically secure token to use as the worker ID. This should be much harder to guess.