### PR TITLE
do not process message for closed workers

### DIFF
--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -559,6 +559,14 @@ class WsockHandler(MixinHandler, tornado.websocket.WebSocketHandler):
     def on_message(self, message):
         logging.debug('{!r} from {}:{}'.format(message, *self.src_addr))
         worker = self.worker_ref()
+        if not worker:
+            # The worker has likely been closed. Do not process.
+            logging.debug(
+                "received message to closed worker from {}:{}".format(
+                    *self.src_addr
+                )
+            )
+            return
         try:
             msg = json.loads(message)
         except JSONDecodeError:


### PR DESCRIPTION
WsockHandler stores a weak reference to the ssh backend worker. The worker closes itself if the backend connection closes (e.g. the user exists the ssh session). That happens in parallel to the websocket handler processing messages, so it is possible for a message to arrive when the worker no longer has any strong references, leading to an exception being thrown.

Handle this case by treating the None worker the same way we do invalid
messages: by simply returning.