### PR TITLE
Change How Custom Font Is Loaded

### DIFF
--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -34,13 +34,13 @@ var wssh = {};
   }
 }());
 
-const findFont = (iterator, familyName) => {
-  if (iterator === undefined) {
+const findFont = (src_list, familyName) => {
+  if (src_list === undefined) {
     return undefined;
   }
-  while (iterator.next()) {
-    if (iterator.family() === familyName) {
-      return iterator;
+  for (font of src_list) {
+    if (font.family === familyName) {
+      return font;
     }
   }
   return undefined;

--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -58,7 +58,7 @@ jQuery(function($){
       form_id = '#connect',
       debug = document.querySelector(form_id).noValidate,
       fonts = document.fonts,
-      custom_font_family_name = $("body").attr("data-wssh-custom-font-family-name", ""),
+      custom_font_family_name = $("body").attr("data-wssh-custom-font-family-name") || "",
       custom_font = findFont(fonts, custom_font_family_name),
       default_fonts,
       DISCONNECTED = 0,

--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -34,6 +34,17 @@ var wssh = {};
   }
 }());
 
+const findFont = (iterator, familyName) => {
+  if (iterator === undefined) {
+    return undefined;
+  }
+  while (iterator.next()) {
+    if (iterator.family() === familyName) {
+      return iterator;
+    }
+  }
+  return undefined;
+}
 
 jQuery(function($){
   var status = $('#status'),
@@ -46,7 +57,9 @@ jQuery(function($){
       title_element = document.querySelector('title'),
       form_id = '#connect',
       debug = document.querySelector(form_id).noValidate,
-      custom_font = document.fonts ? document.fonts.values().next().value : undefined,
+      fonts = document.fonts;
+      custom_font_family_name = $("body").attr("data-wssh-custom-font-family-name", "");
+      custom_font = findFont(fonts, custom_font_family_name),
       default_fonts,
       DISCONNECTED = 0,
       CONNECTING = 1,

--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -57,8 +57,8 @@ jQuery(function($){
       title_element = document.querySelector('title'),
       form_id = '#connect',
       debug = document.querySelector(form_id).noValidate,
-      fonts = document.fonts;
-      custom_font_family_name = $("body").attr("data-wssh-custom-font-family-name", "");
+      fonts = document.fonts,
+      custom_font_family_name = $("body").attr("data-wssh-custom-font-family-name", ""),
       custom_font = findFont(fonts, custom_font_family_name),
       default_fonts,
       DISCONNECTED = 0,

--- a/webssh/templates/index.html
+++ b/webssh/templates/index.html
@@ -36,7 +36,7 @@
       {% end %}
     </style>
   </head>
-  <body>
+  <body {% if font.family %}data-wssh-custom-font-family-name="{{ font.family }}"{% end %}>
     <div id="waiter" style="display: none"> Connecting ... </div>
 
     <div class="container form-container" style="display: none">


### PR DESCRIPTION
# Problem
Currently the custom font is loaded by assuming that it's the first item in `document.fonts`, the problem with this is that some extension (namely Grammarly) will load their own custom fonts. On Firefox it seems like the fonts extensions load gets placed later in the list, but on Chrome the extension's font may be placed first. This results in the terminal font not being set properly and instead being set to the extension's font.

# Solution
Changes `main.js` to search for the font in `document.fonts` by name instead of assuming it's the first. To get the name the `index.html` template has been changed to place a custom data attribute for the font name in the `<body>` tag.
