### PR TITLE
Change order of operations in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,15 @@ FROM python:3-alpine
 LABEL maintainer='<author>'
 LABEL version='0.0.0-dev.0-build.0'
 
-ADD . /code
+ADD requirements.txt /code/requirements.txt
 WORKDIR /code
 RUN \
   apk add --no-cache libc-dev libffi-dev gcc && \
   pip install -r requirements.txt --no-cache-dir && \
-  apk del gcc libc-dev libffi-dev && \
+  apk del gcc libc-dev libffi-dev
+
+ADD . /code
+RUN \
   addgroup webssh && \
   adduser -Ss /bin/false -g webssh webssh && \
   chown -R webssh:webssh /code


### PR DESCRIPTION
Hi,
I was tinkering with the code a little and noticed that the `Dockerfile` could be optimized a little to take advantage of docker's caching.

I've split the run command so all the downloads should only depend on the `requirements.txt` file and not on the whole codebase.