### PR TITLE
feature: add source address support via paramiko sock

### DIFF
--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -377,6 +377,12 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
             raise InvalidValueError('Invalid port: {}'.format(value))
         return port
 
+    def get_source_address(self):
+        value = self.get_value('source_address')
+        if not is_valid_ip_address(value):
+            raise InvalidValueError('Invalid source ip address: {}'.format(value))
+        return value
+
     def lookup_hostname(self, hostname, port):
         key = hostname if port == 22 else '[{}]:{}'.format(hostname, port)
 
@@ -395,6 +401,7 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
         privatekey, filename = self.get_privatekey()
         passphrase = self.get_argument('passphrase', u'')
         totp = self.get_argument('totp', u'')
+        source_address = self.get_source_address()
 
         if isinstance(self.policy, paramiko.RejectPolicy):
             self.lookup_hostname(hostname, port)
@@ -404,8 +411,19 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
         else:
             pkey = None
 
+        if source_address:
+            logging.info("Binding socket for source ip {}".format(source_address))
+            sock = socket.socket()
+            sock.settimeout(options.timeout)  # Set a timeout on blocking socket operations
+            try:
+                sock.bind((source_address, 0))
+            except OSError:
+                raise InvalidValueError('Unable to bind source address {} socket'.format(source_address))
+        else:
+            sock = None
+
         self.ssh_client.totp = totp
-        args = (hostname, port, username, password, pkey)
+        args = (hostname, port, username, password, pkey, sock)
         logging.debug(args)
 
         return args
@@ -450,6 +468,14 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
         ssh = self.ssh_client
         dst_addr = args[:2]
         logging.info('Connecting to {}:{}'.format(*dst_addr))
+
+        sock = args[5]
+        if sock:
+            logging.info('Connecting source address socket')
+            try:
+                sock.connect(dst_addr)
+            except socket.error:
+                raise ValueError('Unable to connect source address socket to {}:{}'.format(*dst_addr))
 
         try:
             ssh.connect(*args, timeout=options.timeout)

--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -378,8 +378,8 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
         return port
 
     def get_source_address(self):
-        value = self.get_value('source_address')
-        if not is_valid_ip_address(value):
+        value = self.get_argument('source_address', u'')
+        if value and not is_valid_ip_address(value):
             raise InvalidValueError('Invalid source ip address: {}'.format(value))
         return value
 

--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -401,7 +401,7 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
         privatekey, filename = self.get_privatekey()
         passphrase = self.get_argument('passphrase', u'')
         totp = self.get_argument('totp', u'')
-        source_address = self.get_source_address()
+        source_address = self.get_argument('source_address', u'')
 
         if isinstance(self.policy, paramiko.RejectPolicy):
             self.lookup_hostname(hostname, port)
@@ -411,19 +411,8 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
         else:
             pkey = None
 
-        if source_address:
-            logging.info("Binding socket for source ip {}".format(source_address))
-            sock = socket.socket()
-            sock.settimeout(options.timeout)  # Set a timeout on blocking socket operations
-            try:
-                sock.bind((source_address, 0))
-            except OSError:
-                raise InvalidValueError('Unable to bind source address {} socket'.format(source_address))
-        else:
-            sock = None
-
         self.ssh_client.totp = totp
-        args = (hostname, port, username, password, pkey, sock)
+        args = (hostname, port, username, password, pkey, source_address)
         logging.debug(args)
 
         return args
@@ -469,16 +458,23 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
         dst_addr = args[:2]
         logging.info('Connecting to {}:{}'.format(*dst_addr))
 
-        sock = args[5]
-        if sock:
+        sock = None
+        source_address = args[5]
+        if source_address:
             logging.info('Connecting source address socket')
+            sock = socket.socket()
+            sock.settimeout(options.timeout)  # Set a timeout on blocking socket operations
+            try:
+                sock.bind((source_address, 0))
+            except OSError:
+                raise InvalidValueError('Unable to bind source address {} socket'.format(source_address))
             try:
                 sock.connect(dst_addr)
             except socket.error:
                 raise ValueError('Unable to connect source address socket to {}:{}'.format(*dst_addr))
 
         try:
-            ssh.connect(*args, timeout=options.timeout)
+            ssh.connect(*args, sock=sock, timeout=options.timeout)
         except socket.error:
             raise ValueError('Unable to connect to {}:{}'.format(*dst_addr))
         except paramiko.BadAuthenticationType:

--- a/webssh/templates/index.html
+++ b/webssh/templates/index.html
@@ -77,6 +77,8 @@
             <input class="form-control" type="password" id="totp" name="totp" value="">
           </div>
           <div class="col">
+            <label for="source_address">Source Address (optional)</label>
+            <input class="form-control" type="text" id="source_address" name="source_address" value="">
           </div>
         </div>
         <input type="hidden" id="term" name="term" value="xterm-256color">


### PR DESCRIPTION
Hi,

I often find myself working on a multi-interface environment to reach different networks.

With paramiko I'm able to achieve this feature using the sock argument:
* https://docs.paramiko.org/en/stable/api/client.html
* https://docs.python.org/3/library/socket.html#module-socket

I was tinkering with the code and managed to integrate this functionality in your project.

I hope you don't mind and if you find it useful it would be nice to have this feature in the original project. If not, I hope this will be helpful for others who are looking for similar functionalities.

Thank you!
