### PR TITLE
handle invalid characeters in encoding

### DIFF
--- a/webssh/utils.py
+++ b/webssh/utils.py
@@ -59,6 +59,8 @@ def is_valid_encoding(encoding):
         u'test'.encode(encoding)
     except LookupError:
         return False
+    except ValueError:
+        return False
     return True
 
 


### PR DESCRIPTION
When establishing a connection to an SSH server, WebSSH tries to guess at its encoding using a command sent prior to opening the terminal. Unfortunately, sometimes this can return data which does not form proper input for the `encode` function used by `is_valid_encoding` to test whether the encoding is known.

In particular, we ran in to a case where the server was returning a string which had a \0 in it when converted to ascii. That raised a `ValueError` (as opposed to `LookupError`), which was uncaught.

Handle the `ValueError` case as well, treating it as an unknown encoding so that we fall back on the default.