### PR TITLE
Secure index with Access Key

### DIFF
--- a/webssh/main.py
+++ b/webssh/main.py
@@ -7,17 +7,21 @@ from webssh import handler
 from webssh.handler import IndexHandler, WsockHandler, NotFoundHandler
 from webssh.settings import (
     get_app_settings,  get_host_keys_settings, get_policy_setting,
-    get_ssl_context, get_server_settings, check_encoding_setting
+    get_ssl_context, get_server_settings, check_encoding_setting,
+    get_access_key
 )
 
 
 def make_handlers(loop, options):
+    logging.info(options)
     host_keys_settings = get_host_keys_settings(options)
     policy = get_policy_setting(options, host_keys_settings)
+    access_key = get_access_key(options)
 
     handlers = [
         (r'/', IndexHandler, dict(loop=loop, policy=policy,
-                                  host_keys_settings=host_keys_settings)),
+                                  host_keys_settings=host_keys_settings,
+                                  access_key=access_key)),
         (r'/ws', WsockHandler, dict(loop=loop))
     ]
     return handlers

--- a/webssh/settings.py
+++ b/webssh/settings.py
@@ -20,6 +20,7 @@ def print_version(flag):
 
 
 define('address', default='', help='Listen address')
+define('accesskey', default='', help='If provided, requests must have a matching url parameter')
 define('port', type=int, default=8888,  help='Listen port')
 define('ssladdress', default='', help='SSL listen address')
 define('sslport', type=int, default=4433,  help='SSL listen port')
@@ -76,7 +77,7 @@ class Font(object):
 def get_app_settings(options):
     settings = dict(
         template_path=os.path.join(base_dir, 'webssh', 'templates'),
-        static_path=os.path.join(base_dir, 'webssh', 'static'),
+        static_path=os.path.join(base_dir,'webssh', 'static'),
         websocket_ping_interval=options.wpintvl,
         debug=options.debug,
         xsrf_cookies=options.xsrf,
@@ -126,6 +127,8 @@ def get_policy_setting(options, host_keys_settings):
     check_policy_setting(policy_class, host_keys_settings)
     return policy_class()
 
+def get_access_key(options):
+    return options.accesskey
 
 def get_ssl_context(options):
     if not options.certfile and not options.keyfile:

--- a/webssh/templates/access_denied.html
+++ b/webssh/templates/access_denied.html
@@ -1,0 +1,8 @@
+<html>
+  <head> </head>
+  <body>
+    <h1>Access Denied</h1>
+	<p>Access key is not present or is invalid</p>
+
+  </body>
+</html>


### PR DESCRIPTION
# Secure index with access key


Added a setting/parameter for an access key. If set, key must be present as a url parameter when requesting index, otherwise the user is redirected to an access denied page.

## Example usage

``` wssh --accesskey="helloworld" ```

## Url to access it

``` https://localhost:4433/?accesskey=helloworld ```


If no access key is given in the command this parameter is not needed to access the page.

